### PR TITLE
Allow packagetrack to run inside of Google App Engine.

### DIFF
--- a/packagetrack/__init__.py
+++ b/packagetrack/__init__.py
@@ -63,7 +63,7 @@ __authors__     = ', '.join(__credits__)
 __license__     = 'GPL'
 __maintainer__  = __credits__[2]
 __status__      = 'Development'
-__version__     = '0.4'
+__version__     = '0.4.1'
 
 from .configuration import ConfigError, DotFileConfig, NullConfig
 from .data import Package

--- a/packagetrack/__init__.py
+++ b/packagetrack/__init__.py
@@ -63,7 +63,7 @@ __authors__     = ', '.join(__credits__)
 __license__     = 'GPL'
 __maintainer__  = __credits__[2]
 __status__      = 'Development'
-__version__     = '0.4.1'
+__version__     = '0.4.2'
 
 from .configuration import ConfigError, DotFileConfig, NullConfig
 from .data import Package

--- a/packagetrack/__init__.py
+++ b/packagetrack/__init__.py
@@ -71,7 +71,7 @@ from .carriers import auto_register_carriers
 
 try:
     config = DotFileConfig()
-except ConfigError:
+except (ConfigError, ImportError):
     config = NullConfig()
 
 auto_register_carriers(config)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fedex==1.0.14
-pytz==2014.2
+fedex==2.4.0
+pytz
 suds==0.4
 wsgiref==0.1.2

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,9 @@ def read(fname):
         content = f.read()
     return content
 
-import packagetrack
-
 setup(
     name='packagetrack',
-    version=packagetrack.__version__,
+    version='0.4.2',
     author="Scott Torborg",
     author_email="storborg@mit.edu",
     license="GPL",


### PR DESCRIPTION
Because of Google App Engine's sandbox, the standard DotFileConfig() fails because of an `ImportError` (it can't `import os`). I added a catch for that so I can use packagetrack inside of GAE.
